### PR TITLE
Reset docking panel position so it appears correctly on small screen

### DIFF
--- a/uiLayout.xml
+++ b/uiLayout.xml
@@ -1,50 +1,54 @@
 <?xml version="1.0"?>
 <VLDocking version="2.1">
-<DockingDesktop name="">
-<DockingPanel x="2220" y="70" width="1177" height="887">
-<Split orientation="1" location="0.5849870578084556">
-<Split orientation="0" location="0.544973544973545">
-<Dockable>
-<Key dockName="EDITOR"/>
-</Dockable>
-<Dockable>
-<Key dockName="MATCHES"/>
-</Dockable>
-</Split>
-<Split orientation="0" location="0.6666666666666666">
-<Split orientation="0" location="0.45">
-<Dockable>
-<Key dockName="SEGMENTPROPERTIES"/>
-</Dockable>
-<Dockable>
-<Key dockName="COMMENTS"/>
-</Dockable>
-</Split>
-<Dockable>
-<Key dockName="MULTIPLE_TRANS"/>
-</Dockable>
-</Split>
-</Split>
-</DockingPanel>
-<Border zone="2">
-<Dockable>
-<Key dockName="DICTIONARY"/>
-<RelativePosition x="0.6000000238418579" y="0.699999988079071" w="0.4000000059604645" h="0.30000001192092896" />
-</Dockable>
-<Dockable>
-<Key dockName="MACHINE_TRANSLATE"/>
-<RelativePosition x="0.6000000238418579" y="0.699999988079071" w="0.4000000059604645" h="0.30000001192092896" />
-</Dockable>
-<Dockable>
-<Key dockName="NOTES"/>
-<RelativePosition x="0.003342245938256383" y="0.005359056871384382" w="0.34558823704719543" h="0.25294747948646545" />
-</Dockable>
-<Dockable>
-<Key dockName="GLOSSARY"/>
-<RelativePosition x="0.003342245938256383" y="0.005359056871384382" w="0.34558823704719543" h="0.9892818927764893" />
-</Dockable>
-</Border>
-<TabGroups>
-</TabGroups>
-</DockingDesktop>
+    <DockingDesktop name="">
+        <DockingPanel x="0" y="0" width="1177" height="887">
+            <Split orientation="1" location="0.5849870578084556">
+                <Split orientation="0" location="0.544973544973545">
+                    <Dockable>
+                        <Key dockName="EDITOR" />
+                    </Dockable>
+                    <Dockable>
+                        <Key dockName="MATCHES" />
+                    </Dockable>
+                </Split>
+                <Split orientation="0" location="0.6666666666666666">
+                    <Split orientation="0" location="0.45">
+                        <Dockable>
+                            <Key dockName="SEGMENTPROPERTIES" />
+                        </Dockable>
+                        <Dockable>
+                            <Key dockName="COMMENTS" />
+                        </Dockable>
+                    </Split>
+                    <Dockable>
+                        <Key dockName="MULTIPLE_TRANS" />
+                    </Dockable>
+                </Split>
+            </Split>
+        </DockingPanel>
+        <Border zone="2">
+            <Dockable>
+                <Key dockName="DICTIONARY" />
+                <RelativePosition x="0.6000000238418579" y="0.699999988079071"
+                    w="0.4000000059604645" h="0.30000001192092896" />
+            </Dockable>
+            <Dockable>
+                <Key dockName="MACHINE_TRANSLATE" />
+                <RelativePosition x="0.6000000238418579" y="0.699999988079071"
+                    w="0.4000000059604645" h="0.30000001192092896" />
+            </Dockable>
+            <Dockable>
+                <Key dockName="NOTES" />
+                <RelativePosition x="0.003342245938256383" y="0.005359056871384382"
+                    w="0.34558823704719543" h="0.25294747948646545" />
+            </Dockable>
+            <Dockable>
+                <Key dockName="GLOSSARY" />
+                <RelativePosition x="0.003342245938256383" y="0.005359056871384382"
+                    w="0.34558823704719543" h="0.9892818927764893" />
+            </Dockable>
+        </Border>
+        <TabGroups>
+        </TabGroups>
+    </DockingDesktop>
 </VLDocking>

--- a/uiLayout.xml
+++ b/uiLayout.xml
@@ -1,54 +1,50 @@
 <?xml version="1.0"?>
 <VLDocking version="2.1">
-    <DockingDesktop name="">
-        <DockingPanel x="0" y="0" width="1177" height="887">
-            <Split orientation="1" location="0.5849870578084556">
-                <Split orientation="0" location="0.544973544973545">
-                    <Dockable>
-                        <Key dockName="EDITOR" />
-                    </Dockable>
-                    <Dockable>
-                        <Key dockName="MATCHES" />
-                    </Dockable>
-                </Split>
-                <Split orientation="0" location="0.6666666666666666">
-                    <Split orientation="0" location="0.45">
-                        <Dockable>
-                            <Key dockName="SEGMENTPROPERTIES" />
-                        </Dockable>
-                        <Dockable>
-                            <Key dockName="COMMENTS" />
-                        </Dockable>
-                    </Split>
-                    <Dockable>
-                        <Key dockName="MULTIPLE_TRANS" />
-                    </Dockable>
-                </Split>
-            </Split>
-        </DockingPanel>
-        <Border zone="2">
-            <Dockable>
-                <Key dockName="DICTIONARY" />
-                <RelativePosition x="0.6000000238418579" y="0.699999988079071"
-                    w="0.4000000059604645" h="0.30000001192092896" />
-            </Dockable>
-            <Dockable>
-                <Key dockName="MACHINE_TRANSLATE" />
-                <RelativePosition x="0.6000000238418579" y="0.699999988079071"
-                    w="0.4000000059604645" h="0.30000001192092896" />
-            </Dockable>
-            <Dockable>
-                <Key dockName="NOTES" />
-                <RelativePosition x="0.003342245938256383" y="0.005359056871384382"
-                    w="0.34558823704719543" h="0.25294747948646545" />
-            </Dockable>
-            <Dockable>
-                <Key dockName="GLOSSARY" />
-                <RelativePosition x="0.003342245938256383" y="0.005359056871384382"
-                    w="0.34558823704719543" h="0.9892818927764893" />
-            </Dockable>
-        </Border>
-        <TabGroups>
-        </TabGroups>
-    </DockingDesktop>
+<DockingDesktop name="">
+<DockingPanel x="0" y="0" width="1177" height="887">
+<Split orientation="1" location="0.5849870578084556">
+<Split orientation="0" location="0.544973544973545">
+<Dockable>
+<Key dockName="EDITOR"/>
+</Dockable>
+<Dockable>
+<Key dockName="MATCHES"/>
+</Dockable>
+</Split>
+<Split orientation="0" location="0.6666666666666666">
+<Split orientation="0" location="0.45">
+<Dockable>
+<Key dockName="SEGMENTPROPERTIES"/>
+</Dockable>
+<Dockable>
+<Key dockName="COMMENTS"/>
+</Dockable>
+</Split>
+<Dockable>
+<Key dockName="MULTIPLE_TRANS"/>
+</Dockable>
+</Split>
+</Split>
+</DockingPanel>
+<Border zone="2">
+<Dockable>
+<Key dockName="DICTIONARY"/>
+<RelativePosition x="0.6000000238418579" y="0.699999988079071" w="0.4000000059604645" h="0.30000001192092896" />
+</Dockable>
+<Dockable>
+<Key dockName="MACHINE_TRANSLATE"/>
+<RelativePosition x="0.6000000238418579" y="0.699999988079071" w="0.4000000059604645" h="0.30000001192092896" />
+</Dockable>
+<Dockable>
+<Key dockName="NOTES"/>
+<RelativePosition x="0.003342245938256383" y="0.005359056871384382" w="0.34558823704719543" h="0.25294747948646545" />
+</Dockable>
+<Dockable>
+<Key dockName="GLOSSARY"/>
+<RelativePosition x="0.003342245938256383" y="0.005359056871384382" w="0.34558823704719543" h="0.9892818927764893" />
+</Dockable>
+</Border>
+<TabGroups>
+</TabGroups>
+</DockingDesktop>
 </VLDocking>


### PR DESCRIPTION
When loaded on a single screen, the current uiLayout.xml makes the main window outside the visible screen