### PR TITLE
customization_dev.groovy: use abs path to ui_layout.xml in update_ui_layout()

### DIFF
--- a/scripts/customization_dev.groovy
+++ b/scripts/customization_dev.groovy
@@ -300,7 +300,8 @@ void fetch_files_by_hash(local_file_hash_map, remote_file_hash_map) {
                 if (remote_file_name == "omegat.prefs") {
                     update_omegat_prefs()
                 } else if (remote_file_name == "uiLayout.xml") {
-                    update_ui_layout()
+                    local_uilayout_fpath = config_dir + File.separator + "uiLayout.xml"
+                    update_ui_layout(local_uilayout_fpath)
                 }
                 console.println("????????????????????????????????????")
             }
@@ -319,9 +320,9 @@ void fetch_files_by_hash(local_file_hash_map, remote_file_hash_map) {
 /** Update the UI Layout with the newly download layout. */
 // XXX This effectively prevents users to make adjustments on the UI layout as it will always be
 // reset with the remote layout at each application restart.
-void update_ui_layout() {
+void update_ui_layout(local_uilayout_fpath) {
     console.println("<<<< HANDLING UI LAYOUT >>>>>")
-    new File("uiLayout.xml").withInputStream(is -> {
+    new File(local_uilayout_fpath).withInputStream(is -> {
         Core.getMainWindow().getDesktop().readXML(is)
     })
 }

--- a/scripts/customization_dev.groovy
+++ b/scripts/customization_dev.groovy
@@ -321,7 +321,7 @@ void fetch_files_by_hash(local_file_hash_map, remote_file_hash_map) {
 // reset with the remote layout at each application restart.
 void update_ui_layout(File local_uilayout) {
     console.println("<<<< HANDLING UI LAYOUT >>>>>")
-    new File(local_uilayout_fpath).withInputStream(is -> {
+    local_uilayout.withInputStream(is -> {
         Core.getMainWindow().getDesktop().readXML(is)
     })
 }

--- a/scripts/customization_dev.groovy
+++ b/scripts/customization_dev.groovy
@@ -319,7 +319,7 @@ void fetch_files_by_hash(local_file_hash_map, remote_file_hash_map) {
 /** Update the UI Layout with the newly download layout. */
 // XXX This effectively prevents users to make adjustments on the UI layout as it will always be
 // reset with the remote layout at each application restart.
-void update_ui_layout(local_uilayout_fpath) {
+void update_ui_layout(File local_uilayout) {
     console.println("<<<< HANDLING UI LAYOUT >>>>>")
     new File(local_uilayout_fpath).withInputStream(is -> {
         Core.getMainWindow().getDesktop().readXML(is)

--- a/scripts/customization_dev.groovy
+++ b/scripts/customization_dev.groovy
@@ -300,8 +300,7 @@ void fetch_files_by_hash(local_file_hash_map, remote_file_hash_map) {
                 if (remote_file_name == "omegat.prefs") {
                     update_omegat_prefs()
                 } else if (remote_file_name == "uiLayout.xml") {
-                    local_uilayout_fpath = config_dir + File.separator + "uiLayout.xml"
-                    update_ui_layout(local_uilayout_fpath)
+                    update_ui_layout(new File(config_dir, "uiLayout.xml"))
                 }
                 console.println("????????????????????????????????????")
             }


### PR DESCRIPTION
Hi @briacp I was getting the following error in the `update_ui_layout`: 

```
download_asset: https://raw.githubusercontent.com/capstanlqc/omegat-user-config/master/uiLayout.xml
remote_file_name: uiLayout.xml
file_location_rel_path_str: uiLayout.xml
local_path_to_location: /home/souto/.omegat610-dev-custom/uiLayout.xml
>> DOWNLOAD uiLayout.xml to uiLayout.xml
%% local_file: /home/souto/.omegat610-dev-custom/uiLayout.xml
<<<< HANDLING UI LAYOUT >>>>>
An error occurred
javax.script.ScriptException: javax.script.ScriptException: java.io.FileNotFoundException: uiLayout.xml (No such file or directory)
```

If I understand what this function tries to do, I think that's because it was trying to use the file name (or relative path to the file) and it couldn't find the file. 

I have used the absolute path to the local file as a argument to the function, and it seems to work now. Could you please review that this is the intended logic? Thank you.